### PR TITLE
feat: Go 1.25とgolangci-lint v2にアップグレード

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -16,7 +16,7 @@ jobs:
     - name: Set up Go 1.x
       uses: actions/setup-go@v5
       with:
-        go-version: '1.23'
+        go-version: '1.25'
 
     - name: Check out code into the Go module directory
       uses: actions/checkout@v2

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -14,10 +14,10 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: golangci-lint
-        uses: golangci/golangci-lint-action@v6
+        uses: golangci/golangci-lint-action@v8
         with:
-          # Required: the version of golangci-lint is required and must be specified without patch version: we always use the latest patch version.
-          version: v1.62
+          # Use latest golangci-lint version (v2.x supports Go 1.25)
+          version: latest
 
           # Optional: working directory, useful for monorepos
           # working-directory: somedir

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module golife
 
-go 1.23
+go 1.25
 
 require github.com/nsf/termbox-go v0.0.0-20201124104050-ed494de23a00
 


### PR DESCRIPTION
## 概要
Goの最新安定版とlintツールを最新バージョンにアップグレードしました。

## 変更内容

### Goバージョン
- **Go 1.23 → Go 1.25.3** (最新安定版、2025年10月13日リリース)

### CI/CDアップデート
- **golangci-lint-action**: v6 → v8
- **golangci-lint**: v1.62 → latest (v2.x)
  - v2.4.0以降でGo 1.25をサポート

### 更新ファイル
- `go.mod`: Go 1.25に更新
- `.github/workflows/go.yml`: Go 1.25に更新
- `.github/workflows/lint.yml`: golangci-lint-action v8、version: latest

## 動作確認
- ✅ `make build` - ビルド成功
- ✅ `make tidy` - go.mod整理成功
- ✅ `golangci-lint run` - lint成功 (0 issues)

## 技術的背景
- Go 1.25は2025年8月12日リリース、最新パッチ版は1.25.3
- golangci-lint v2はGo 1.25でビルドされており完全サポート
- 現在サポートされているGoバージョン: 1.24と1.25

🤖 Generated with [Claude Code](https://claude.com/claude-code)