### PR TITLE
chore: Dependabotの設定を追加

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  # Go modules
+  - package-ecosystem: "gomod"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "go"
+    commit-message:
+      prefix: "chore"
+      include: "scope"
+
+  # GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "monday"
+      time: "09:00"
+      timezone: "Asia/Tokyo"
+    open-pull-requests-limit: 5
+    labels:
+      - "dependencies"
+      - "github-actions"
+    commit-message:
+      prefix: "chore"
+      include: "scope"


### PR DESCRIPTION
## 概要
依存関係を自動的に最新に保つためにDependabotを設定しました。

## 設定内容

### 📦 監視対象

#### 1. Go modules (`gomod`)
- **対象**: `go.mod`の依存関係
- **ディレクトリ**: `/`
- **ラベル**: `dependencies`, `go`

#### 2. GitHub Actions
- **対象**: ワークフローで使用するアクション
- **ディレクトリ**: `/`
- **ラベル**: `dependencies`, `github-actions`

### ⏰ スケジュール
- **頻度**: 毎週
- **曜日**: 月曜日
- **時刻**: 09:00 JST (Asia/Tokyo)
- **同時PR数**: 最大5つ

### 📝 コミットメッセージ
- **プレフィックス**: `chore`
- **スコープ**: 含む

## 期待される効果

### ✅ メリット
1. **自動更新**: 依存関係が自動的に最新版に
2. **セキュリティ**: 脆弱性の早期発見と修正
3. **最新機能**: 新しい機能の活用
4. **メンテナンス**: 手動更新の負担軽減

### 🔄 動作イメージ
```
毎週月曜日 09:00
    ↓
Dependabotが依存関係をチェック
    ↓
更新があればPR自動作成
    ↓
CIが自動実行
    ↓
レビュー & マージ
```

## 対象依存関係

### Go modules
- `github.com/nsf/termbox-go`
- `github.com/mattn/go-runewidth`

### GitHub Actions
- `actions/checkout@v4`
- `actions/setup-go@v5`
- `golangci/golangci-lint-action@v8`
- `codecov/codecov-action@v4`

🤖 Generated with [Claude Code](https://claude.com/claude-code)