### PR TITLE
fix: Go 1.24サポートを削除し、1.25専用に

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,21 +25,18 @@ jobs:
         with:
           version: latest
 
-  # Test job with multiple Go versions
+  # Test job
   test:
-    name: Test (Go ${{ matrix.go-version }})
+    name: Test
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        go-version: ['1.24', '1.25']
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
 
-      - name: Set up Go ${{ matrix.go-version }}
+      - name: Set up Go
         uses: actions/setup-go@v5
         with:
-          go-version: ${{ matrix.go-version }}
+          go-version: '1.25'
 
       - name: Get dependencies
         run: go mod download
@@ -51,7 +48,6 @@ jobs:
         run: go tool cover -func=coverage.out
 
       - name: Upload coverage to Codecov
-        if: matrix.go-version == '1.25'
         uses: codecov/codecov-action@v5
         with:
           file: ./coverage.out


### PR DESCRIPTION
## 概要
actions/setup-go v6の破壊的変更に対応するため、Go 1.24サポートを削除しました。

## 🐛 問題

PR #27 (Dependabotのactions/setup-go v5→v6更新)が失敗していました:

```
go: go.mod requires go >= 1.25 (running go 1.24.7; GOTOOLCHAIN=local)
```

### 根本原因

**actions/setup-go v6の破壊的変更**:
- `GOTOOLCHAIN=local`がデフォルトで設定される
- 異なるGoバージョンの自動インストールが無効化
- `go.mod`が`go 1.25`を要求しているのに、CIで`go 1.24`を使用すると失敗

参考: [actions/setup-go v6.0.0 Release Notes](https://github.com/actions/setup-go/releases/tag/v6.0.0)

## ✅ 解決策

Go 1.25のみをサポートすることで、actions/setup-go v6との互換性を確保:

### 変更内容

#### Before (マトリックス戦略)
```yaml
test:
  name: Test (Go ${{ matrix.go-version }})
  strategy:
    matrix:
      go-version: ['1.24', '1.25']
```

#### After (単一バージョン)
```yaml
test:
  name: Test
  steps:
    - name: Set up Go
      uses: actions/setup-go@v5
      with:
        go-version: '1.25'
```

## 📊 メリット

1. **CI実行時間の短縮**: マトリックスなしで約50%短縮
2. **シンプル化**: 1つのGoバージョンのみ管理
3. **最新機能**: Go 1.25の機能をフル活用
4. **互換性**: actions/setup-go v6と完全互換

## 🔄 影響

- ✅ PR #27 (actions/setup-go v6)がマージ可能に
- ✅ Dependabotの自動更新が正常動作
- ⚠️ Go 1.24のサポート終了

## 関連

- 依存: PR #27 (actions/setup-go v6アップグレード)
- 修正: Go 1.24でのテスト失敗

🤖 Generated with [Claude Code](https://claude.com/claude-code)