### PR TITLE
feat: コマンドライン引数で設定可能なパラメータを追加

### DIFF
--- a/main.go
+++ b/main.go
@@ -1,17 +1,35 @@
 package main
 
 import (
+	"flag"
+	"fmt"
 	"math/rand"
 	"time"
 
 	termbox "github.com/nsf/termbox-go"
 )
 
+// Default values
+const (
+	defaultWidth       = 100
+	defaultHeight      = 40
+	defaultSpeed       = 200
+	defaultGenerations = 300
+)
+
+// Configuration variables
+var (
+	width       int
+	height      int
+	speed       int
+	generations int
+)
+
 // DX is width
-var DX = 100
+var DX = defaultWidth
 
 // DY is height
-var DY = 40
+var DY = defaultHeight
 
 func randomize() [][]int {
 	result := make([][]int, DY)
@@ -95,27 +113,57 @@ func flush(data [][]int) error {
 
 }
 
+func init() {
+	flag.IntVar(&width, "width", defaultWidth, "Grid width")
+	flag.IntVar(&height, "height", defaultHeight, "Grid height")
+	flag.IntVar(&speed, "speed", defaultSpeed, "Animation speed in milliseconds")
+	flag.IntVar(&generations, "generations", defaultGenerations, "Number of generations to simulate")
+}
+
 func main() {
+	flag.Parse()
+
+	// Validate parameters
+	if width <= 0 || height <= 0 {
+		fmt.Println("Error: width and height must be positive integers")
+		flag.Usage()
+		return
+	}
+	if speed <= 0 {
+		fmt.Println("Error: speed must be a positive integer")
+		flag.Usage()
+		return
+	}
+	if generations <= 0 {
+		fmt.Println("Error: generations must be a positive integer")
+		flag.Usage()
+		return
+	}
+
+	// Update global dimensions
+	DX = width
+	DY = height
+
 	var matrix = randomize()
 
 	err := termbox.Init()
 	if err != nil {
 		panic(err)
 	}
+	defer termbox.Close()
+
 	err = termbox.Clear(termbox.ColorDefault, termbox.ColorDefault)
 	if err != nil {
 		panic(err)
 	}
 
-	for i := 0; i < 300; i++ {
+	for i := 0; i < generations; i++ {
 		matrix = step(matrix)
 		err = flush(matrix)
 		if err != nil {
 			panic(err)
 		}
 
-		time.Sleep(200 * time.Millisecond)
+		time.Sleep(time.Duration(speed) * time.Millisecond)
 	}
-
-	defer termbox.Close()
 }


### PR DESCRIPTION
## 概要
Issue #14 の実装。グリッドサイズ、アニメーション速度、世代数をコマンドライン引数で指定可能にしました。

## 変更内容

### 追加機能
- `--width`: グリッド幅の指定（デフォルト: 100）
- `--height`: グリッド高さの指定（デフォルト: 40）
- `--speed`: アニメーション速度（ミリ秒）の指定（デフォルト: 200）
- `--generations`: シミュレーション世代数の指定（デフォルト: 300）

### 使用例
```bash
# デフォルト設定で実行
./golife

# カスタムパラメータで実行
./golife --width=150 --height=50 --speed=100 --generations=500

# 高速な小さいグリッド
./golife --width=50 --height=20 --speed=50 --generations=1000

# ヘルプの表示
./golife --help
```

### 実装の詳細
1. **flag パッケージの使用**: 標準ライブラリの `flag` パッケージでコマンドライン引数をパース
2. **パラメータのバリデーション**: 
   - width, height > 0
   - speed > 0
   - generations > 0
   - バリデーションエラー時はヘルプメッセージを表示して終了
3. **デフォルト値の定数化**: マジックナンバーを排除し、定数として定義
4. **既存機能の維持**: 引数なしでも従来通り動作

## テスト結果

### ユニットテスト
```
✓ TestRandomize
✓ TestStepSurvivalRules (4 subtests)
✓ TestStepBirthRule (2 subtests)
✓ TestStepEdgeCases (4 subtests)
✓ TestStepKnownPatterns (2 subtests)
✓ TestStepEmptyGrid
```
すべてのテストが通過

### 品質チェック
```
✓ go fmt
✓ go vet
✓ go test
```

### 手動テスト
- ✅ `--help` フラグでヘルプメッセージが正しく表示される
- ✅ 無効なwidth（0以下）でエラーメッセージが表示される
- ✅ 無効なspeed（負の値）でエラーメッセージが表示される
- ✅ 無効なgenerations（0）でエラーメッセージが表示される
- ✅ デフォルト値で正常に動作する

## 期待される効果
- ✅ ユーザーが柔軟にシミュレーションをカスタマイズ可能
- ✅ 様々な環境・端末サイズに対応
- ✅ デモや実験での調整が容易
- ✅ 後方互換性の維持（引数なしでも動作）

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)