### PR TITLE
feat: セルの年齢に基づくカラフル表示機能を追加

### DIFF
--- a/color_test.go
+++ b/color_test.go
@@ -1,0 +1,245 @@
+package main
+
+import (
+	"testing"
+
+	termbox "github.com/nsf/termbox-go"
+)
+
+// TestGetColorByAge tests the color assignment based on cell age
+func TestGetColorByAge(t *testing.T) {
+	testCases := []struct {
+		name          string
+		age           int
+		expectedColor termbox.Attribute
+	}{
+		{
+			name:          "Dead cell (age 0)",
+			age:           0,
+			expectedColor: termbox.ColorDefault,
+		},
+		{
+			name:          "Newborn cell (age 1)",
+			age:           1,
+			expectedColor: termbox.ColorGreen,
+		},
+		{
+			name:          "Young cell (age 2)",
+			age:           2,
+			expectedColor: termbox.ColorYellow,
+		},
+		{
+			name:          "Young cell (age 3)",
+			age:           3,
+			expectedColor: termbox.ColorYellow,
+		},
+		{
+			name:          "Old cell (age 4)",
+			age:           4,
+			expectedColor: termbox.ColorRed,
+		},
+		{
+			name:          "Old cell (age 10)",
+			age:           10,
+			expectedColor: termbox.ColorRed,
+		},
+		{
+			name:          "Very old cell (age 11)",
+			age:           11,
+			expectedColor: termbox.ColorBlue,
+		},
+		{
+			name:          "Very old cell (age 100)",
+			age:           100,
+			expectedColor: termbox.ColorBlue,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			result := getColorByAge(tc.age)
+			if result != tc.expectedColor {
+				t.Errorf("Expected color %v for age %d, got %v", tc.expectedColor, tc.age, result)
+			}
+		})
+	}
+}
+
+// TestStepWithAge tests the age tracking functionality
+func TestStepWithAge(t *testing.T) {
+	// Save original DX and DY
+	originalDX := DX
+	originalDY := DY
+	DX = 5
+	DY = 5
+	defer func() {
+		DX = originalDX
+		DY = originalDY
+	}()
+
+	testCases := []struct {
+		name           string
+		grid           [][]int
+		ageMap         [][]int
+		expectedGrid   [][]int
+		expectedAgeMap [][]int
+		checkPosition  [2]int
+		expectedAge    int
+		description    string
+	}{
+		{
+			name: "Newborn cell gets age 1",
+			grid: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 1, 1, 0, 0},
+				{0, 1, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			ageMap: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 5, 5, 0, 0},
+				{0, 5, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			expectedGrid: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 1, 1, 0, 0},
+				{0, 1, 1, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			checkPosition: [2]int{2, 2}, // y=2, x=2
+			expectedAge:   1,
+			description:   "Newly born cell at (2,2) should have age 1",
+		},
+		{
+			name: "Surviving cell increments age",
+			grid: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 1, 1, 0, 0},
+				{0, 1, 1, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			ageMap: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 5, 5, 0, 0},
+				{0, 5, 5, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			expectedGrid: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 1, 1, 0, 0},
+				{0, 1, 1, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			checkPosition: [2]int{1, 1}, // y=1, x=1
+			expectedAge:   6,
+			description:   "Surviving cell at (1,1) should increment from age 5 to 6",
+		},
+		{
+			name: "Dead cell has age 0",
+			grid: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 1, 0, 0, 0},
+				{0, 1, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			ageMap: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 10, 0, 0, 0},
+				{0, 10, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			expectedGrid: [][]int{
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+				{0, 0, 0, 0, 0},
+			},
+			checkPosition: [2]int{1, 1}, // y=1, x=1
+			expectedAge:   0,
+			description:   "Dead cell should have age 0",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			resultGrid, resultAgeMap := stepWithAge(tc.grid, tc.ageMap)
+
+			// Verify the grid state
+			for y := 0; y < DY; y++ {
+				for x := 0; x < DX; x++ {
+					if resultGrid[y][x] != tc.expectedGrid[y][x] {
+						t.Errorf("Grid mismatch at [%d][%d]: expected %d, got %d",
+							y, x, tc.expectedGrid[y][x], resultGrid[y][x])
+					}
+				}
+			}
+
+			// Verify the specific age
+			y, x := tc.checkPosition[0], tc.checkPosition[1]
+			if resultAgeMap[y][x] != tc.expectedAge {
+				t.Errorf("%s: expected age %d at [%d][%d], got %d",
+					tc.description, tc.expectedAge, y, x, resultAgeMap[y][x])
+			}
+		})
+	}
+}
+
+// TestStepWithAgeProgression tests age progression over multiple generations
+func TestStepWithAgeProgression(t *testing.T) {
+	// Save original DX and DY
+	originalDX := DX
+	originalDY := DY
+	DX = 5
+	DY = 5
+	defer func() {
+		DX = originalDX
+		DY = originalDY
+	}()
+
+	// Start with a stable block pattern (2x2)
+	grid := [][]int{
+		{0, 0, 0, 0, 0},
+		{0, 1, 1, 0, 0},
+		{0, 1, 1, 0, 0},
+		{0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0},
+	}
+
+	ageMap := [][]int{
+		{0, 0, 0, 0, 0},
+		{0, 1, 1, 0, 0},
+		{0, 1, 1, 0, 0},
+		{0, 0, 0, 0, 0},
+		{0, 0, 0, 0, 0},
+	}
+
+	// Simulate 10 generations
+	for gen := 1; gen <= 10; gen++ {
+		grid, ageMap = stepWithAge(grid, ageMap)
+
+		// Block pattern should remain stable
+		// All cells in the block should have age = gen + 1
+		expectedAge := gen + 1
+		for y := 1; y <= 2; y++ {
+			for x := 1; x <= 2; x++ {
+				if grid[y][x] != 1 {
+					t.Errorf("Generation %d: Block cell at [%d][%d] should be alive", gen, y, x)
+				}
+				if ageMap[y][x] != expectedAge {
+					t.Errorf("Generation %d: Expected age %d at [%d][%d], got %d",
+						gen, expectedAge, y, x, ageMap[y][x])
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## 概要
Issue #19 の実装。セルの年齢に応じて色分けして表示する機能を追加しました。

## 色の割り当て

セルの年齢に基づいて以下のように色分けされます：

| 年齢 | 色 | 説明 |
|------|-----|------|
| 0 | デフォルト（白） | 死亡セル |
| 1 | 緑（Green） | 新生セル |
| 2-3 | 黄色（Yellow） | 若いセル |
| 4-10 | 赤（Red） | 古いセル |
| 11+ | 青（Blue） | 非常に古いセル |

## 使用例

### 基本的な使用
```bash
# 年齢ベースの色表示
./golife --color=age

# 色なし（デフォルト）
./golife
```

### パターンと組み合わせ
```bash
# パルサーパターンで色表示
./golife --pattern=pulsar --color=age

# グライダーをゆっくり観察
./golife --pattern=glider --color=age --speed=500

# グライダーガンで長時間観察
./golife --pattern=glider-gun --width=150 --height=60 --color=age --generations=500
```

### 統計情報と組み合わせ
```bash
# 色と統計の両方を表示
./golife --pattern=pulsar --color=age --stats

# すべてのオプションを使用
./golife --width=120 --height=50 --pattern=glider-gun --color=age --stats --speed=100
```

## 実装の詳細

### 年齢追跡システム

#### 1. stepWithAge() 関数
通常の `step()` 関数に加えて、セルの年齢を追跡する関数を追加：

```go
func stepWithAge(data [][]int, ageMap [][]int) ([][]int, [][]int)
```

**ロジック**:
- 生存セル（2-3の隣接セル）: 年齢をインクリメント
- 新生セル（正確に3の隣接セル）: 年齢1で誕生
- 死亡セル: 年齢0にリセット

#### 2. getColorByAge() 関数
年齢から termbox の色属性を返す：

```go
func getColorByAge(age int) termbox.Attribute
```

#### 3. flushWithColor() 関数
年齢マップを使用してカラー表示：

```go
func flushWithColor(data [][]int, ageMap [][]int) error
```

### コマンドラインフラグ

```bash
--color string    Color mode: 'age' for age-based coloring
```

現在は `age` モードのみサポート。将来的に他のモード（状態ベース、グラデーションなど）を追加可能な設計。

### メインループの変更

```go
// 色モードが有効な場合、年齢マップを初期化
if colorMode == "age" {
    ageMap = make([][]int, DY)
    // 初期グリッドに基づいて年齢1を設定
}

// 各世代で
if useColorMode {
    matrix, ageMap = stepWithAge(matrix, ageMap)
    termboxErr = flushWithColor(matrix, ageMap)
} else {
    matrix = step(matrix)
    termboxErr = flush(matrix)
}
```

## テスト結果

### 新規テストスイート（color_test.go）

**TestGetColorByAge (8 subtests)**
```
✓ Dead cell (age 0) → ColorDefault
✓ Newborn cell (age 1) → ColorGreen
✓ Young cell (age 2) → ColorYellow
✓ Young cell (age 3) → ColorYellow
✓ Old cell (age 4) → ColorRed
✓ Old cell (age 10) → ColorRed
✓ Very old cell (age 11) → ColorBlue
✓ Very old cell (age 100) → ColorBlue
```

**TestStepWithAge (3 subtests)**
```
✓ Newborn cell gets age 1
✓ Surviving cell increments age
✓ Dead cell has age 0
```

**TestStepWithAgeProgression**
- 安定パターン（2x2ブロック）で10世代シミュレート
- 各セルの年齢が正しく1→2→3...→11と増加
- すべてのセルが安定して生存し続けることを確認

### 既存テスト
すべての既存テスト（main_test.go, patterns_test.go, statistics_test.go）も引き続き通過

### 品質チェック
```
✓ go fmt
✓ go vet
✓ go test (17 test functions, 38 subtests)
All quality checks passed!
```

## 技術的な特徴

### 1. パフォーマンス最適化
- `--color`フラグが未指定の場合、年齢追跡を完全にスキップ
- 既存の `step()` と `flush()` 関数を保持し、後方互換性を維持
- 年齢マップは色モード時のみ初期化・更新

### 2. 拡張性のある設計
- `colorMode` 変数で将来的な色モード追加に対応
- `getColorByAge()` 関数で色のカスタマイズが容易
- 年齢の閾値（1, 3, 10）を定数化すれば調整可能

### 3. 視覚的な魅力
- termbox の基本8色を効果的に活用
- 緑→黄→赤→青の順で年齢を表現
- セルのライフサイクルが直感的に理解できる

## パターンごとの色の見え方

### Blinker（周期2振動子）
- セルが周期的に誕生・死亡するため、常に緑（age 1）と黄色（age 2-3）
- 振動パターンの動きが色で強調される

### Block（静止物体）
- セルが移動しないため、徐々に赤→青に変化
- 安定パターンであることが一目瞭然

### Pulsar（周期3振動子）
- 複雑な振動パターンが色のグラデーションで表現される
- 緑・黄・赤が周期的に出現

### Glider（移動パターン）
- 移動しながら形を変えるため、様々な色が混在
- 一部のセルは古くなり、新しいセルが生まれる

### Gosper's Glider Gun
- グライダーを生成し続けるため、カラフルな表示
- 銃本体は徐々に青くなり、生成されるグライダーは緑から始まる

## 期待される効果

### 教育的価値
- セルのライフサイクルを視覚的に理解
- パターンの安定性・振動性を色で識別
- 新旧のセルの混在状況を一目で把握

### デモンストレーション
- より魅力的なビジュアル表示
- プレゼンテーションでの訴求力向上
- ライフゲームの面白さを直感的に伝達

### 分析ツール
- 長寿セルの位置を特定（青色）
- 活発な領域を識別（緑・黄色が多い）
- パターンの進化を追跡

## 後方互換性

- `--color` フラグはオプション（デフォルト: 無効）
- 既存のコマンドラインオプションはすべて動作
- 色機能は既存のシミュレーションロジックに影響なし
- step() と flush() の既存関数を保持

## 将来の拡張可能性

現在の実装は `--color=age` のみですが、以下の拡張が容易：

1. **状態ベースの色分け** (`--color=state`)
   - 安定セル: 青
   - 振動セル: 黄
   - 移動セル: 緑

2. **グラデーション表示** (`--color=gradient`)
   - 隣接セル数に応じた濃淡

3. **カスタムテーマ** (`--theme=retro`)
   - レトロ風の配色
   - ダーク/ライトモード

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)