### PR TITLE
feat: 層間相互作用ルールの実装

### DIFF
--- a/pkg/rules/layer_interaction.go
+++ b/pkg/rules/layer_interaction.go
@@ -1,0 +1,193 @@
+package rules
+
+import "golife/pkg/core"
+
+// LayerInteractionType defines how layers interact in 2.5D universe
+type LayerInteractionType int
+
+const (
+	// NoInteraction - layers evolve independently
+	NoInteraction LayerInteractionType = iota
+	// WeightedNeighbors - vertical neighbors contribute with weight
+	WeightedNeighbors
+	// BirthBetweenLayers - cells can only birth between existing layers
+	BirthBetweenLayers
+	// EnergyDiffusion - cell states diffuse between layers
+	EnergyDiffusion
+)
+
+// LayerInteractionRule defines how cells interact across layers in 2.5D
+type LayerInteractionRule interface {
+	// Type returns the interaction type
+	Type() LayerInteractionType
+
+	// CalculateNeighborCount calculates effective neighbor count considering vertical layers
+	// horizontalNeighbors: count from same layer (0-8 for Moore)
+	// verticalNeighbors: count from upper and lower layers (0-18)
+	// currentState: current cell state
+	// upperState, lowerState: cell states in layers above/below
+	CalculateNeighborCount(horizontalNeighbors, verticalNeighbors int, currentState, upperState, lowerState core.CellState) int
+
+	// ShouldBirth determines if a dead cell should be born
+	// neighborCount: effective neighbor count from CalculateNeighborCount
+	// upperState, lowerState: cell states in layers above/below
+	ShouldBirth(neighborCount int, upperState, lowerState core.CellState) bool
+
+	// ShouldSurvive determines if a live cell should survive
+	// neighborCount: effective neighbor count from CalculateNeighborCount
+	// currentState: current cell state
+	// upperState, lowerState: cell states in layers above/below
+	ShouldSurvive(neighborCount int, currentState, upperState, lowerState core.CellState) bool
+}
+
+// WeightedNeighborsRule implements weighted neighbor counting
+type WeightedNeighborsRule struct {
+	baseRule       core.Rule
+	verticalWeight float64 // 0.0-1.0
+}
+
+// NewWeightedNeighborsRule creates a new weighted neighbors rule
+func NewWeightedNeighborsRule(baseRule core.Rule, verticalWeight float64) *WeightedNeighborsRule {
+	if verticalWeight < 0.0 {
+		verticalWeight = 0.0
+	}
+	if verticalWeight > 1.0 {
+		verticalWeight = 1.0
+	}
+	return &WeightedNeighborsRule{
+		baseRule:       baseRule,
+		verticalWeight: verticalWeight,
+	}
+}
+
+func (r *WeightedNeighborsRule) Type() LayerInteractionType {
+	return WeightedNeighbors
+}
+
+func (r *WeightedNeighborsRule) CalculateNeighborCount(horizontalNeighbors, verticalNeighbors int, currentState, upperState, lowerState core.CellState) int {
+	// Weighted total: horizontal + (vertical × weight)
+	totalNeighbors := float64(horizontalNeighbors) + float64(verticalNeighbors)*r.verticalWeight
+	return int(totalNeighbors + 0.5) // Round to nearest int
+}
+
+func (r *WeightedNeighborsRule) ShouldBirth(neighborCount int, upperState, lowerState core.CellState) bool {
+	return r.baseRule.ShouldBirth(neighborCount)
+}
+
+func (r *WeightedNeighborsRule) ShouldSurvive(neighborCount int, currentState, upperState, lowerState core.CellState) bool {
+	return r.baseRule.ShouldSurvive(neighborCount, currentState)
+}
+
+// BirthBetweenLayersRule allows birth only where adjacent layers have live cells
+type BirthBetweenLayersRule struct {
+	baseRule          core.Rule
+	requireBothLayers bool // If true, both upper AND lower must have cells
+}
+
+// NewBirthBetweenLayersRule creates a new birth between layers rule
+func NewBirthBetweenLayersRule(baseRule core.Rule, requireBothLayers bool) *BirthBetweenLayersRule {
+	return &BirthBetweenLayersRule{
+		baseRule:          baseRule,
+		requireBothLayers: requireBothLayers,
+	}
+}
+
+func (r *BirthBetweenLayersRule) Type() LayerInteractionType {
+	return BirthBetweenLayers
+}
+
+func (r *BirthBetweenLayersRule) CalculateNeighborCount(horizontalNeighbors, verticalNeighbors int, currentState, upperState, lowerState core.CellState) int {
+	// Only horizontal neighbors count
+	return horizontalNeighbors
+}
+
+func (r *BirthBetweenLayersRule) ShouldBirth(neighborCount int, upperState, lowerState core.CellState) bool {
+	// Check base rule first
+	if !r.baseRule.ShouldBirth(neighborCount) {
+		return false
+	}
+
+	// Check layer condition
+	hasUpper := upperState > core.Dead
+	hasLower := lowerState > core.Dead
+
+	if r.requireBothLayers {
+		// Requires cells in both adjacent layers
+		return hasUpper && hasLower
+	} else {
+		// Requires cells in at least one adjacent layer
+		return hasUpper || hasLower
+	}
+}
+
+func (r *BirthBetweenLayersRule) ShouldSurvive(neighborCount int, currentState, upperState, lowerState core.CellState) bool {
+	return r.baseRule.ShouldSurvive(neighborCount, currentState)
+}
+
+// EnergyDiffusionRule treats cell state as energy that diffuses between layers
+type EnergyDiffusionRule struct {
+	baseRule        core.Rule
+	diffusionRate   float64 // 0.0-1.0, how much energy transfers
+	energyThreshold uint8   // Minimum energy for cell to be "alive"
+}
+
+// NewEnergyDiffusionRule creates a new energy diffusion rule
+func NewEnergyDiffusionRule(baseRule core.Rule, diffusionRate float64, energyThreshold uint8) *EnergyDiffusionRule {
+	if diffusionRate < 0.0 {
+		diffusionRate = 0.0
+	}
+	if diffusionRate > 1.0 {
+		diffusionRate = 1.0
+	}
+	if energyThreshold == 0 {
+		energyThreshold = 1
+	}
+	return &EnergyDiffusionRule{
+		baseRule:        baseRule,
+		diffusionRate:   diffusionRate,
+		energyThreshold: energyThreshold,
+	}
+}
+
+func (r *EnergyDiffusionRule) Type() LayerInteractionType {
+	return EnergyDiffusion
+}
+
+func (r *EnergyDiffusionRule) CalculateNeighborCount(horizontalNeighbors, verticalNeighbors int, currentState, upperState, lowerState core.CellState) int {
+	// Count neighbors based on energy threshold
+	effectiveVertical := 0
+
+	// Add diffused energy from vertical neighbors
+	diffusedEnergy := (float64(upperState) + float64(lowerState)) * r.diffusionRate
+
+	// If diffused energy exceeds threshold, count as neighbors
+	if diffusedEnergy >= float64(r.energyThreshold) {
+		effectiveVertical = int(diffusedEnergy / float64(r.energyThreshold))
+	}
+
+	return horizontalNeighbors + effectiveVertical
+}
+
+func (r *EnergyDiffusionRule) ShouldBirth(neighborCount int, upperState, lowerState core.CellState) bool {
+	return r.baseRule.ShouldBirth(neighborCount)
+}
+
+func (r *EnergyDiffusionRule) ShouldSurvive(neighborCount int, currentState, upperState, lowerState core.CellState) bool {
+	return r.baseRule.ShouldSurvive(neighborCount, currentState)
+}
+
+// GetDiffusedEnergy calculates the new energy level after diffusion
+func (r *EnergyDiffusionRule) GetDiffusedEnergy(currentEnergy, upperEnergy, lowerEnergy core.CellState) core.CellState {
+	// Energy diffuses from adjacent layers
+	incomingEnergy := (float64(upperEnergy) + float64(lowerEnergy)) * r.diffusionRate / 2.0
+
+	// Current energy decays slightly
+	decayedEnergy := float64(currentEnergy) * (1.0 - r.diffusionRate*0.1)
+
+	totalEnergy := decayedEnergy + incomingEnergy
+
+	if totalEnergy > 255 {
+		return 255
+	}
+	return core.CellState(totalEnergy)
+}

--- a/pkg/rules/layer_interaction_test.go
+++ b/pkg/rules/layer_interaction_test.go
@@ -1,0 +1,247 @@
+package rules
+
+import (
+	"golife/pkg/core"
+	"testing"
+)
+
+// Mock rule for testing
+type mockRule struct{}
+
+func (r mockRule) Name() string { return "Mock" }
+func (r mockRule) ShouldBirth(neighborCount int) bool {
+	return neighborCount == 3
+}
+func (r mockRule) ShouldSurvive(neighborCount int, currentState core.CellState) bool {
+	if currentState == core.Dead {
+		return false
+	}
+	return neighborCount == 2 || neighborCount == 3
+}
+func (r mockRule) NeighborWeight(distance float64) float64 { return 1.0 }
+
+func TestWeightedNeighborsRule(t *testing.T) {
+	baseRule := mockRule{}
+	rule := NewWeightedNeighborsRule(baseRule, 0.5)
+
+	if rule.Type() != WeightedNeighbors {
+		t.Errorf("Expected WeightedNeighbors type, got %d", rule.Type())
+	}
+
+	// Test neighbor calculation: 3 horizontal + 10 vertical × 0.5 = 3 + 5 = 8
+	neighborCount := rule.CalculateNeighborCount(3, 10, core.Dead, core.Alive, core.Alive)
+	if neighborCount != 8 {
+		t.Errorf("Expected 8 neighbors, got %d", neighborCount)
+	}
+
+	// Test birth rule (should follow base rule)
+	if !rule.ShouldBirth(3, core.Dead, core.Dead) {
+		t.Error("Should birth with 3 neighbors")
+	}
+	if rule.ShouldBirth(2, core.Dead, core.Dead) {
+		t.Error("Should not birth with 2 neighbors")
+	}
+
+	// Test survival rule
+	if !rule.ShouldSurvive(2, core.Alive, core.Dead, core.Dead) {
+		t.Error("Should survive with 2 neighbors")
+	}
+	if rule.ShouldSurvive(1, core.Alive, core.Dead, core.Dead) {
+		t.Error("Should not survive with 1 neighbor")
+	}
+}
+
+func TestWeightedNeighborsRule_WeightBounds(t *testing.T) {
+	baseRule := mockRule{}
+
+	// Test weight < 0
+	rule1 := NewWeightedNeighborsRule(baseRule, -0.5)
+	count1 := rule1.CalculateNeighborCount(5, 10, core.Dead, core.Dead, core.Dead)
+	if count1 != 5 {
+		t.Errorf("Negative weight should be clamped to 0, expected 5, got %d", count1)
+	}
+
+	// Test weight > 1.0
+	rule2 := NewWeightedNeighborsRule(baseRule, 1.5)
+	count2 := rule2.CalculateNeighborCount(5, 10, core.Dead, core.Dead, core.Dead)
+	if count2 != 15 { // 5 + 10*1.0
+		t.Errorf("Weight > 1.0 should be clamped to 1.0, expected 15, got %d", count2)
+	}
+}
+
+func TestBirthBetweenLayersRule_SingleLayer(t *testing.T) {
+	baseRule := mockRule{}
+	rule := NewBirthBetweenLayersRule(baseRule, false) // Requires at least one layer
+
+	if rule.Type() != BirthBetweenLayers {
+		t.Errorf("Expected BirthBetweenLayers type, got %d", rule.Type())
+	}
+
+	// Test neighbor calculation (only horizontal counts)
+	neighborCount := rule.CalculateNeighborCount(3, 10, core.Dead, core.Alive, core.Alive)
+	if neighborCount != 3 {
+		t.Errorf("Expected 3 neighbors, got %d", neighborCount)
+	}
+
+	// Test birth with upper layer having cells
+	if !rule.ShouldBirth(3, core.Alive, core.Dead) {
+		t.Error("Should birth when upper layer has cells and neighbor count is 3")
+	}
+
+	// Test birth with lower layer having cells
+	if !rule.ShouldBirth(3, core.Dead, core.Alive) {
+		t.Error("Should birth when lower layer has cells and neighbor count is 3")
+	}
+
+	// Test birth with no adjacent layer cells
+	if rule.ShouldBirth(3, core.Dead, core.Dead) {
+		t.Error("Should not birth when no adjacent layer has cells")
+	}
+
+	// Test birth with wrong neighbor count
+	if rule.ShouldBirth(2, core.Alive, core.Alive) {
+		t.Error("Should not birth with 2 neighbors even if layers have cells")
+	}
+}
+
+func TestBirthBetweenLayersRule_BothLayers(t *testing.T) {
+	baseRule := mockRule{}
+	rule := NewBirthBetweenLayersRule(baseRule, true) // Requires both layers
+
+	// Test birth with both layers having cells
+	if !rule.ShouldBirth(3, core.Alive, core.Alive) {
+		t.Error("Should birth when both layers have cells and neighbor count is 3")
+	}
+
+	// Test birth with only upper layer
+	if rule.ShouldBirth(3, core.Alive, core.Dead) {
+		t.Error("Should not birth when only upper layer has cells (requires both)")
+	}
+
+	// Test birth with only lower layer
+	if rule.ShouldBirth(3, core.Dead, core.Alive) {
+		t.Error("Should not birth when only lower layer has cells (requires both)")
+	}
+
+	// Test survival is not affected
+	if !rule.ShouldSurvive(2, core.Alive, core.Dead, core.Dead) {
+		t.Error("Survival should not require layer conditions")
+	}
+}
+
+func TestEnergyDiffusionRule(t *testing.T) {
+	baseRule := mockRule{}
+	rule := NewEnergyDiffusionRule(baseRule, 0.5, 10)
+
+	if rule.Type() != EnergyDiffusion {
+		t.Errorf("Expected EnergyDiffusion type, got %d", rule.Type())
+	}
+
+	// Test with high energy in adjacent layers
+	// upper = 100, lower = 100, diffusionRate = 0.5
+	// diffused = (100 + 100) * 0.5 = 100
+	// effective vertical = 100 / 10 = 10
+	neighborCount := rule.CalculateNeighborCount(3, 0, core.Dead, 100, 100)
+	expected := 3 + 10 // horizontal + diffused
+	if neighborCount != expected {
+		t.Errorf("Expected %d neighbors, got %d", expected, neighborCount)
+	}
+
+	// Test with low energy
+	neighborCount2 := rule.CalculateNeighborCount(3, 0, core.Dead, 5, 5)
+	// diffused = (5 + 5) * 0.5 = 5, which is below threshold 10
+	if neighborCount2 != 3 {
+		t.Errorf("Expected 3 neighbors (no diffusion below threshold), got %d", neighborCount2)
+	}
+}
+
+func TestEnergyDiffusionRule_Bounds(t *testing.T) {
+	baseRule := mockRule{}
+
+	// Test negative diffusion rate
+	rule1 := NewEnergyDiffusionRule(baseRule, -0.5, 10)
+	count1 := rule1.CalculateNeighborCount(5, 0, core.Dead, 100, 100)
+	if count1 != 5 {
+		t.Errorf("Negative diffusion rate should be clamped to 0, expected 5, got %d", count1)
+	}
+
+	// Test diffusion rate > 1.0
+	rule2 := NewEnergyDiffusionRule(baseRule, 1.5, 10)
+	count2 := rule2.CalculateNeighborCount(5, 0, core.Dead, 100, 100)
+	expected := 5 + ((100 + 100) * 1.0 / 10) // clamped to 1.0
+	if count2 != int(expected) {
+		t.Errorf("Diffusion rate > 1.0 should be clamped to 1.0, expected %d, got %d", int(expected), count2)
+	}
+
+	// Test zero threshold (should default to 1)
+	rule3 := NewEnergyDiffusionRule(baseRule, 0.5, 0)
+	count3 := rule3.CalculateNeighborCount(5, 0, core.Dead, 10, 10)
+	// diffused = (10 + 10) * 0.5 = 10, threshold should be 1, so 10/1 = 10
+	if count3 != 15 {
+		t.Errorf("Zero threshold should default to 1, expected 15, got %d", count3)
+	}
+}
+
+func TestEnergyDiffusionRule_GetDiffusedEnergy(t *testing.T) {
+	baseRule := mockRule{}
+	rule := NewEnergyDiffusionRule(baseRule, 0.5, 10)
+
+	// Test energy diffusion
+	newEnergy := rule.GetDiffusedEnergy(50, 100, 100)
+	// current decays: 50 * (1 - 0.5*0.1) = 50 * 0.95 = 47.5
+	// incoming: (100 + 100) * 0.5 / 2 = 50
+	// total: 47.5 + 50 = 97.5 ≈ 97
+	if newEnergy < 95 || newEnergy > 100 {
+		t.Errorf("Expected energy around 97, got %d", newEnergy)
+	}
+
+	// Test energy cap at 255
+	newEnergy2 := rule.GetDiffusedEnergy(200, 200, 200)
+	if newEnergy2 != 255 {
+		t.Errorf("Energy should be capped at 255, got %d", newEnergy2)
+	}
+
+	// Test with zero energy
+	newEnergy3 := rule.GetDiffusedEnergy(0, 20, 20)
+	// incoming: (20 + 20) * 0.5 / 2 = 10
+	if newEnergy3 != 10 {
+		t.Errorf("Expected energy 10 from diffusion, got %d", newEnergy3)
+	}
+}
+
+func BenchmarkWeightedNeighborsRule(b *testing.B) {
+	baseRule := mockRule{}
+	rule := NewWeightedNeighborsRule(baseRule, 0.3)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rule.CalculateNeighborCount(5, 10, core.Alive, core.Alive, core.Alive)
+		rule.ShouldBirth(3, core.Alive, core.Alive)
+		rule.ShouldSurvive(2, core.Alive, core.Alive, core.Alive)
+	}
+}
+
+func BenchmarkBirthBetweenLayersRule(b *testing.B) {
+	baseRule := mockRule{}
+	rule := NewBirthBetweenLayersRule(baseRule, false)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rule.CalculateNeighborCount(5, 10, core.Alive, core.Alive, core.Alive)
+		rule.ShouldBirth(3, core.Alive, core.Alive)
+		rule.ShouldSurvive(2, core.Alive, core.Alive, core.Alive)
+	}
+}
+
+func BenchmarkEnergyDiffusionRule(b *testing.B) {
+	baseRule := mockRule{}
+	rule := NewEnergyDiffusionRule(baseRule, 0.5, 10)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		rule.CalculateNeighborCount(5, 10, 50, 100, 100)
+		rule.ShouldBirth(3, 100, 100)
+		rule.ShouldSurvive(2, 50, 100, 100)
+		rule.GetDiffusedEnergy(50, 100, 100)
+	}
+}

--- a/pkg/universe/universe25d_interaction_test.go
+++ b/pkg/universe/universe25d_interaction_test.go
@@ -1,0 +1,248 @@
+package universe
+
+import (
+	"golife/pkg/core"
+	"golife/pkg/rules"
+	"testing"
+)
+
+func TestUniverse25D_WithWeightedNeighborsRule(t *testing.T) {
+	u := New25D(20, 20, 3, rules.ConwayRule{})
+
+	// Set custom weighted rule
+	customRule := rules.NewWeightedNeighborsRule(rules.ConwayRule{}, 0.8)
+	u.SetInteractionRule(customRule)
+	u.SetLayerInteraction(true)
+
+	// Verify rule was set
+	if u.GetInteractionRule().Type() != rules.WeightedNeighbors {
+		t.Error("Interaction rule type should be WeightedNeighbors")
+	}
+
+	// Create a simple pattern
+	u.layers[1].Set(core.NewCoord2D(10, 10), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(11, 10), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(10, 11), core.Alive)
+
+	initialCount := u.CountLiving()
+	if initialCount != 3 {
+		t.Errorf("Expected 3 initial cells, got %d", initialCount)
+	}
+
+	// Step with weighted rule
+	u.Step()
+
+	// Pattern should evolve
+	afterCount := u.CountLiving()
+	t.Logf("Cells after step with weighted rule: %d", afterCount)
+
+	// Verify interaction is working
+	if afterCount == 0 {
+		t.Error("All cells died - interaction may not be working")
+	}
+}
+
+func TestUniverse25D_WithBirthBetweenLayersRule(t *testing.T) {
+	u := New25D(20, 20, 3, rules.ConwayRule{})
+
+	// Set birth between layers rule (requires at least one adjacent layer)
+	customRule := rules.NewBirthBetweenLayersRule(rules.ConwayRule{}, false)
+	u.SetInteractionRule(customRule)
+	u.SetLayerInteraction(true)
+
+	// Create pattern with cells in layer 0 and 2, but empty layer 1
+	// This should allow birth in layer 1 if horizontal neighbors are right
+	u.layers[0].Set(core.NewCoord2D(10, 10), core.Alive)
+	u.layers[2].Set(core.NewCoord2D(10, 10), core.Alive)
+
+	// Add pattern in layer 1 that would normally birth (glider)
+	u.layers[1].Set(core.NewCoord2D(10, 9), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(11, 10), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(9, 11), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(10, 11), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(11, 11), core.Alive)
+
+	initialCount := u.CountLiving()
+	t.Logf("Initial cells: %d", initialCount)
+
+	u.Step()
+
+	afterCount := u.CountLiving()
+	t.Logf("Cells after step with birth-between-layers rule: %d", afterCount)
+
+	// The pattern should evolve with layer constraints
+	if afterCount == 0 {
+		t.Error("All cells died")
+	}
+}
+
+func TestUniverse25D_WithBirthBetweenLayersRule_BothRequired(t *testing.T) {
+	u := New25D(20, 20, 3, rules.ConwayRule{})
+
+	// Set birth between layers rule (requires both adjacent layers)
+	customRule := rules.NewBirthBetweenLayersRule(rules.ConwayRule{}, true)
+	u.SetInteractionRule(customRule)
+	u.SetLayerInteraction(true)
+
+	// Pattern in middle layer with cells in both adjacent layers
+	u.layers[0].Set(core.NewCoord2D(10, 10), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(10, 9), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(11, 10), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(9, 11), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(10, 11), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(11, 11), core.Alive)
+	u.layers[2].Set(core.NewCoord2D(10, 10), core.Alive)
+
+	initialCount := u.CountLiving()
+	t.Logf("Initial cells: %d", initialCount)
+
+	u.Step()
+
+	afterCount := u.CountLiving()
+	t.Logf("Cells after step with both-layers-required rule: %d", afterCount)
+
+	// Pattern should be more constrained
+	if afterCount == 0 {
+		t.Error("All cells died")
+	}
+}
+
+func TestUniverse25D_WithEnergyDiffusionRule(t *testing.T) {
+	u := New25D(20, 20, 3, rules.ConwayRule{})
+
+	// Set energy diffusion rule
+	customRule := rules.NewEnergyDiffusionRule(rules.ConwayRule{}, 0.5, 10)
+	u.SetInteractionRule(customRule)
+	u.SetLayerInteraction(true)
+
+	// Create high-energy pattern in top layer
+	for y := 9; y <= 11; y++ {
+		for x := 9; x <= 11; x++ {
+			u.layers[0].Set(core.NewCoord2D(x, y), 100) // High energy
+		}
+	}
+
+	// Middle layer has some cells
+	u.layers[1].Set(core.NewCoord2D(10, 10), core.Alive)
+
+	initialEnergy := 0
+	for z := 0; z < 3; z++ {
+		for y := 0; y < 20; y++ {
+			for x := 0; x < 20; x++ {
+				state := u.layers[z].Get(core.NewCoord2D(x, y))
+				initialEnergy += int(state)
+			}
+		}
+	}
+
+	t.Logf("Initial total energy: %d", initialEnergy)
+
+	u.Step()
+
+	afterEnergy := 0
+	for z := 0; z < 3; z++ {
+		for y := 0; y < 20; y++ {
+			for x := 0; x < 20; x++ {
+				state := u.layers[z].Get(core.NewCoord2D(x, y))
+				afterEnergy += int(state)
+			}
+		}
+	}
+
+	t.Logf("Total energy after step: %d", afterEnergy)
+
+	// Energy should diffuse between layers
+	// Note: This test just verifies the rule runs without error
+	// Actual energy behavior depends on complex interactions
+}
+
+func TestUniverse25D_SwitchBetweenRules(t *testing.T) {
+	u := New25D(10, 10, 3, rules.ConwayRule{})
+
+	// Start with weighted rule
+	rule1 := rules.NewWeightedNeighborsRule(rules.ConwayRule{}, 0.3)
+	u.SetInteractionRule(rule1)
+
+	if u.GetInteractionRule().Type() != rules.WeightedNeighbors {
+		t.Error("Should have WeightedNeighbors rule")
+	}
+
+	// Switch to birth-between-layers
+	rule2 := rules.NewBirthBetweenLayersRule(rules.ConwayRule{}, false)
+	u.SetInteractionRule(rule2)
+
+	if u.GetInteractionRule().Type() != rules.BirthBetweenLayers {
+		t.Error("Should have BirthBetweenLayers rule")
+	}
+
+	// Switch to energy diffusion
+	rule3 := rules.NewEnergyDiffusionRule(rules.ConwayRule{}, 0.5, 10)
+	u.SetInteractionRule(rule3)
+
+	if u.GetInteractionRule().Type() != rules.EnergyDiffusion {
+		t.Error("Should have EnergyDiffusion rule")
+	}
+}
+
+func TestUniverse25D_BackwardCompatibility(t *testing.T) {
+	// Test that old SetVerticalWeight still works
+	u := New25D(10, 10, 3, rules.ConwayRule{})
+
+	u.SetVerticalWeight(0.7)
+	u.SetLayerInteraction(true)
+
+	// Verify the interaction rule was updated
+	if u.GetInteractionRule().Type() != rules.WeightedNeighbors {
+		t.Error("SetVerticalWeight should update interaction rule to WeightedNeighbors")
+	}
+
+	// Add pattern and step
+	u.layers[1].Set(core.NewCoord2D(5, 5), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(6, 5), core.Alive)
+	u.layers[1].Set(core.NewCoord2D(5, 6), core.Alive)
+
+	u.Step()
+
+	// Should not panic or error
+	afterCount := u.CountLiving()
+	t.Logf("Cells after step with backward-compatible API: %d", afterCount)
+}
+
+func BenchmarkUniverse25D_WeightedNeighborsRule(b *testing.B) {
+	u := New25D(50, 50, 10, rules.ConwayRule{})
+	u.Randomize()
+	rule := rules.NewWeightedNeighborsRule(rules.ConwayRule{}, 0.3)
+	u.SetInteractionRule(rule)
+	u.SetLayerInteraction(true)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		u.Step()
+	}
+}
+
+func BenchmarkUniverse25D_BirthBetweenLayersRule(b *testing.B) {
+	u := New25D(50, 50, 10, rules.ConwayRule{})
+	u.Randomize()
+	rule := rules.NewBirthBetweenLayersRule(rules.ConwayRule{}, false)
+	u.SetInteractionRule(rule)
+	u.SetLayerInteraction(true)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		u.Step()
+	}
+}
+
+func BenchmarkUniverse25D_EnergyDiffusionRule(b *testing.B) {
+	u := New25D(50, 50, 10, rules.ConwayRule{})
+	u.Randomize()
+	rule := rules.NewEnergyDiffusionRule(rules.ConwayRule{}, 0.5, 10)
+	u.SetInteractionRule(rule)
+	u.SetLayerInteraction(true)
+
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		u.Step()
+	}
+}


### PR DESCRIPTION
## 概要

2.5Dにおける層間の影響を定義する3種類のルール体系を実装しました。

## 実装内容

### LayerInteractionRuleインターフェース

```go
type LayerInteractionRule interface {
    Type() LayerInteractionType
    CalculateNeighborCount(horizontalNeighbors, verticalNeighbors int, 
                          currentState, upperState, lowerState core.CellState) int
    ShouldBirth(neighborCount int, upperState, lowerState core.CellState) bool
    ShouldSurvive(neighborCount int, currentState, upperState, lowerState core.CellState) bool
}
```

### ルール1: WeightedNeighborsRule (重み付き近傍)

**特徴**:
- 垂直方向の近傍を重み付けでカウント
- 計算式: `totalNeighbors = horizontal + (vertical × weight)`
- デフォルト重み: 0.3 (30%)

**使用例**:
```go
rule := rules.NewWeightedNeighborsRule(rules.ConwayRule{}, 0.5)
u.SetInteractionRule(rule)
```

**パフォーマンス**: 809μs/op, 54,804 B/op, 31 allocs/op

### ルール2: BirthBetweenLayersRule (層間誕生ルール)

**特徴**:
- 上下の層にセルがある場所でのみ誕生可能
- 2モード: 単層モード (どちらか) / 両層必須モード

**使用例**:
```go
// 単層モード (上下どちらかに生存セルがあればOK)
rule := rules.NewBirthBetweenLayersRule(rules.ConwayRule{}, false)

// 両層必須モード
rule := rules.NewBirthBetweenLayersRule(rules.ConwayRule{}, true)
```

**パフォーマンス**: 798μs/op, 54,800 B/op, 31 allocs/op

### ルール3: EnergyDiffusionRule (エネルギー拡散)

**特徴**:
- セル状態(0-255)をエネルギーとして扱う
- 上下の層からエネルギーが拡散
- 拡散率とエネルギー閾値を設定可能

**使用例**:
```go
rule := rules.NewEnergyDiffusionRule(rules.ConwayRule{}, 0.5, 10)
u.SetInteractionRule(rule)
```

**パフォーマンス**: 796μs/op, 54,800 B/op, 31 allocs/op

### GetDiffusedEnergy
エネルギー拡散ルール専用メソッド:
```go
newEnergy := rule.GetDiffusedEnergy(currentEnergy, upperEnergy, lowerEnergy)
```

## Universe25Dの更新

### 新しいAPI
```go
// ルールを設定
u.SetInteractionRule(rule)

// 現在のルールを取得
currentRule := u.GetInteractionRule()

// ルールタイプを確認
if currentRule.Type() == rules.WeightedNeighbors {
    // ...
}
```

### 後方互換性
既存の`SetVerticalWeight()`も引き続き動作:
```go
u.SetVerticalWeight(0.7)  // 内部でWeightedNeighborsRuleに変換
```

## テスト

### 単体テスト
- `TestWeightedNeighborsRule`: 重み付き計算の検証
- `TestBirthBetweenLayersRule_SingleLayer`: 単層モード
- `TestBirthBetweenLayersRule_BothLayers`: 両層必須モード
- `TestEnergyDiffusionRule`: エネルギー拡散
- 境界値テスト (重み、拡散率、閾値)

### 統合テスト
- `TestUniverse25D_WithWeightedNeighborsRule`
- `TestUniverse25D_WithBirthBetweenLayersRule`
- `TestUniverse25D_WithEnergyDiffusionRule`
- `TestUniverse25D_SwitchBetweenRules`: ルール切り替え
- `TestUniverse25D_BackwardCompatibility`: 後方互換性

### ベンチマーク結果 (50×50×10グリッド)
```
BenchmarkUniverse25D_WeightedNeighborsRule-14     1460   809294 ns/op   54804 B/op   31 allocs/op
BenchmarkUniverse25D_BirthBetweenLayersRule-14    1528   798000 ns/op   54800 B/op   31 allocs/op
BenchmarkUniverse25D_EnergyDiffusionRule-14       1509   796244 ns/op   54800 B/op   31 allocs/op
```

全てのルールがほぼ同等のパフォーマンス(約800μs/op)

## 設計判断

1. **インターフェースベース設計**: 
   - ルールの追加・切り替えが容易
   - 実行時のルール変更対応

2. **後方互換性の維持**:
   - 既存のAPIは全て動作継続
   - `SetVerticalWeight()`は内部でWeightedNeighborsRuleに変換

3. **パラメータの境界チェック**:
   - 重み: 0.0-1.0に制限
   - 拡散率: 0.0-1.0に制限
   - 閾値: 最小1

## Phase 1進捗

- [x] Issue #46: Universe25Dの実装 (PR #73)
- [x] Issue #47: 層間相互作用ルール (このPR)
- [ ] Issue #48: 2.5D可視化
- [ ] Issue #49: 2.5Dパターン

🤖 Generated with [Claude Code](https://claude.com/claude-code)