### PR TITLE
docs: Makefileに2.5Dデモ実行ターゲットを追加

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -16,7 +16,7 @@ BINARY_WINDOWS=$(BINARY_NAME).exe
 # Build directory
 BUILD_DIR=bin
 
-.PHONY: all build clean test coverage run run-auto run-pattern help fmt vet quality deps tidy
+.PHONY: all build clean test coverage run run-auto run-pattern demo-multi demo-25d help fmt vet quality deps tidy
 
 # Default target
 all: help
@@ -28,6 +28,8 @@ help:
 	@echo "  make run          - Run with interactive mode and all features"
 	@echo "  make run-auto     - Run automatic mode (100 generations)"
 	@echo "  make run-pattern  - Run with Gosper's Glider Gun pattern"
+	@echo "  make demo-multi   - Run multi-layer 2.5D visualization demo"
+	@echo "  make demo-25d     - Run 2.5D patterns catalog demo"
 	@echo "  make test         - Run tests"
 	@echo "  make coverage     - Run tests with coverage report"
 	@echo "  make quality      - Run all quality checks (fmt, vet, test)"
@@ -60,6 +62,16 @@ run-auto: build
 run-pattern: build
 	@echo "Running $(BINARY_NAME) with Gosper's Glider Gun pattern..."
 	@./$(BUILD_DIR)/$(BINARY_NAME) --interactive --stats --color age --pattern glider-gun --speed 100
+
+## demo-multi: Run multi-layer 2.5D visualization demo
+demo-multi:
+	@echo "Running multi-layer 2.5D visualization demo..."
+	$(GOCMD) run examples/multi-layer/main.go
+
+## demo-25d: Run 2.5D patterns catalog demo
+demo-25d:
+	@echo "Running 2.5D patterns catalog demo..."
+	$(GOCMD) run examples/25d-patterns/main.go
 
 ## test: Run tests
 test:


### PR DESCRIPTION
## 概要

Phase 1で実装した2.5D機能のデモを簡単に実行できるように、Makefileに2つの新しいターゲットを追加しました。

## 変更内容

### 新しいMakeターゲット

1. **`make demo-multi`** - マルチレイヤー2.5D可視化デモ
   - `examples/multi-layer/main.go` を実行
   - 4種類のレイアウト（Single/Horizontal/Vertical/Grid）のデモンストレーション
   - レイヤー間相互作用の可視化

2. **`make demo-25d`** - 2.5Dパターンカタログデモ
   - `examples/25d-patterns/main.go` を実行
   - 6種類の2.5D専用パターンの紹介と進化のデモ
   - 異なるルールでの比較デモ

### その他の変更

- `.PHONY` に新しいターゲットを追加
- `make help` の出力に新しいターゲットの説明を追加

## 使用例

```bash
# マルチレイヤー可視化デモを実行
make demo-multi

# 2.5Dパターンカタログデモを実行
make demo-25d
```

## テスト

- `make help` で新しいターゲットが表示されることを確認
- 両方のデモが正常に実行されることを確認済み

## 関連Issue

Phase 1 (2.5D実装) の完了に伴う追加機能
- Issue #47: 層間相互作用ルール
- Issue #48: 2.5D可視化
- Issue #49: 2.5Dパターン

🤖 Generated with [Claude Code](https://claude.com/claude-code)