### PR TITLE
refactor: 型安全性の向上（Pattern2DをCellStateに統一） (#91)

### DIFF
--- a/pkg/patterns/patterns2d.go
+++ b/pkg/patterns/patterns2d.go
@@ -11,16 +11,16 @@ type Pattern2D struct {
 	Description string
 	Width       int
 	Height      int
-	Cells       [][]int // 1 = alive, 0 = dead
+	Cells       [][]core.CellState
 }
 
 // LoadIntoUniverse loads this pattern into a universe at the given offset
 func (p *Pattern2D) LoadIntoUniverse(u *universe.Universe2D, offsetX, offsetY int) {
 	for y := 0; y < len(p.Cells) && y < p.Height; y++ {
 		for x := 0; x < len(p.Cells[y]) && x < p.Width; x++ {
-			if p.Cells[y][x] == 1 {
+			if p.Cells[y][x] != core.Dead {
 				coord := core.NewCoord2D(offsetX+x, offsetY+y)
-				u.Set(coord, core.Alive)
+				u.Set(coord, p.Cells[y][x])
 			}
 		}
 	}
@@ -28,118 +28,140 @@ func (p *Pattern2D) LoadIntoUniverse(u *universe.Universe2D, offsetX, offsetY in
 
 // Glider returns the classic glider pattern
 func Glider() Pattern2D {
+	const (
+		O = core.Dead
+		X = core.Alive
+	)
 	return Pattern2D{
 		Name:        "Glider",
 		Description: "A small pattern that moves diagonally",
 		Width:       3,
 		Height:      3,
-		Cells: [][]int{
-			{0, 1, 0},
-			{0, 0, 1},
-			{1, 1, 1},
+		Cells: [][]core.CellState{
+			{O, X, O},
+			{O, O, X},
+			{X, X, X},
 		},
 	}
 }
 
 // Blinker returns a period-2 oscillator
 func Blinker() Pattern2D {
+	const X = core.Alive
 	return Pattern2D{
 		Name:        "Blinker",
 		Description: "A period-2 oscillator",
 		Width:       3,
 		Height:      1,
-		Cells: [][]int{
-			{1, 1, 1},
+		Cells: [][]core.CellState{
+			{X, X, X},
 		},
 	}
 }
 
 // Toad returns a period-2 oscillator
 func Toad() Pattern2D {
+	const (
+		O = core.Dead
+		X = core.Alive
+	)
 	return Pattern2D{
 		Name:        "Toad",
 		Description: "A period-2 oscillator",
 		Width:       4,
 		Height:      2,
-		Cells: [][]int{
-			{0, 1, 1, 1},
-			{1, 1, 1, 0},
+		Cells: [][]core.CellState{
+			{O, X, X, X},
+			{X, X, X, O},
 		},
 	}
 }
 
 // Beacon returns a period-2 oscillator
 func Beacon() Pattern2D {
+	const (
+		O = core.Dead
+		X = core.Alive
+	)
 	return Pattern2D{
 		Name:        "Beacon",
 		Description: "A period-2 oscillator",
 		Width:       4,
 		Height:      4,
-		Cells: [][]int{
-			{1, 1, 0, 0},
-			{1, 1, 0, 0},
-			{0, 0, 1, 1},
-			{0, 0, 1, 1},
+		Cells: [][]core.CellState{
+			{X, X, O, O},
+			{X, X, O, O},
+			{O, O, X, X},
+			{O, O, X, X},
 		},
 	}
 }
 
 // Pulsar returns a period-3 oscillator
 func Pulsar() Pattern2D {
+	const (
+		O = core.Dead
+		X = core.Alive
+	)
 	return Pattern2D{
 		Name:        "Pulsar",
 		Description: "A period-3 oscillator",
 		Width:       13,
 		Height:      13,
-		Cells: [][]int{
-			{0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1},
-			{1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1},
-			{1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1},
-			{0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0},
-			{1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1},
-			{1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1},
-			{1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 1},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{0, 0, 1, 1, 1, 0, 0, 0, 1, 1, 1, 0, 0},
+		Cells: [][]core.CellState{
+			{O, O, X, X, X, O, O, O, X, X, X, O, O},
+			{O, O, O, O, O, O, O, O, O, O, O, O, O},
+			{X, O, O, O, O, X, O, X, O, O, O, O, X},
+			{X, O, O, O, O, X, O, X, O, O, O, O, X},
+			{X, O, O, O, O, X, O, X, O, O, O, O, X},
+			{O, O, X, X, X, O, O, O, X, X, X, O, O},
+			{O, O, O, O, O, O, O, O, O, O, O, O, O},
+			{O, O, X, X, X, O, O, O, X, X, X, O, O},
+			{X, O, O, O, O, X, O, X, O, O, O, O, X},
+			{X, O, O, O, O, X, O, X, O, O, O, O, X},
+			{X, O, O, O, O, X, O, X, O, O, O, O, X},
+			{O, O, O, O, O, O, O, O, O, O, O, O, O},
+			{O, O, X, X, X, O, O, O, X, X, X, O, O},
 		},
 	}
 }
 
 // GliderGun returns the Gosper Glider Gun
 func GliderGun() Pattern2D {
+	const (
+		O = core.Dead
+		X = core.Alive
+	)
 	return Pattern2D{
 		Name:        "Gosper Glider Gun",
 		Description: "A pattern that generates gliders",
 		Width:       36,
 		Height:      9,
-		Cells: [][]int{
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1},
-			{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 1, 1, 0, 0, 0, 0, 1, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 0, 0, 0, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
-			{0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 1, 1, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0},
+		Cells: [][]core.CellState{
+			{O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, X, O, O, O, O, O, O, O, O, O, O, O},
+			{O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, X, O, X, O, O, O, O, O, O, O, O, O, O, O},
+			{O, O, O, O, O, O, O, O, O, O, O, O, X, X, O, O, O, O, O, O, X, X, O, O, O, O, O, O, O, O, O, O, O, O, X, X},
+			{O, O, O, O, O, O, O, O, O, O, O, X, O, O, O, X, O, O, O, O, X, X, O, O, O, O, O, O, O, O, O, O, O, O, X, X},
+			{X, X, O, O, O, O, O, O, O, O, X, O, O, O, O, O, X, O, O, O, X, X, O, O, O, O, O, O, O, O, O, O, O, O, O, O},
+			{X, X, O, O, O, O, O, O, O, O, X, O, O, O, X, O, X, X, O, O, O, O, X, O, X, O, O, O, O, O, O, O, O, O, O, O},
+			{O, O, O, O, O, O, O, O, O, O, X, O, O, O, O, O, X, O, O, O, O, O, O, O, X, O, O, O, O, O, O, O, O, O, O, O},
+			{O, O, O, O, O, O, O, O, O, O, O, X, O, O, O, X, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O},
+			{O, O, O, O, O, O, O, O, O, O, O, O, X, X, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O, O},
 		},
 	}
 }
 
 // Block returns a still life (2x2 square)
 func Block() Pattern2D {
+	const X = core.Alive
 	return Pattern2D{
 		Name:        "Block",
 		Description: "A still life (stable pattern)",
 		Width:       2,
 		Height:      2,
-		Cells: [][]int{
-			{1, 1},
-			{1, 1},
+		Cells: [][]core.CellState{
+			{X, X},
+			{X, X},
 		},
 	}
 }

--- a/pkg/universe/universe2d.go
+++ b/pkg/universe/universe2d.go
@@ -181,6 +181,8 @@ func (u *Universe2D) GetAge(x, y int) int {
 }
 
 // GetCells returns the internal cell array (for compatibility with legacy code)
+//
+// Deprecated: Use Get(coord) with core.CellState instead for type-safe access.
 func (u *Universe2D) GetCells() [][]int {
 	result := make([][]int, u.height)
 	for y := 0; y < u.height; y++ {
@@ -197,6 +199,8 @@ func (u *Universe2D) GetCells() [][]int {
 }
 
 // SetCells sets cells from a 2D int array (for compatibility with legacy code)
+//
+// Deprecated: Use Set(coord, state) with core.CellState instead for type-safe access.
 func (u *Universe2D) SetCells(cells [][]int) {
 	for y := 0; y < u.height && y < len(cells); y++ {
 		for x := 0; x < u.width && x < len(cells[y]); x++ {


### PR DESCRIPTION
## 概要

Issue #91に対応し、`Pattern2D`の型安全性を向上させました。`[][]int`（マジックナンバー）から`[][]core.CellState`（型付き）に変更し、コードの安全性と可読性を向上させました。

## 変更内容

### pkg/patterns/patterns2d.go

#### 型の変更
- `Pattern2D.Cells`を`[][]int`から`[][]core.CellState`に変更
- すべてのパターン関数で`core.CellState`を使用

#### パターン定義の改善
各パターン関数で定数を使用し、視覚的な可読性を向上：

```go
// Before
Cells: [][]int{
    {0, 1, 0},
    {0, 0, 1},
    {1, 1, 1},
}

// After
const (
    O = core.Dead
    X = core.Alive
)
Cells: [][]core.CellState{
    {O, X, O},
    {O, O, X},
    {X, X, X},
}
```

#### LoadIntoUniverseの改善
マジックナンバー比較から型安全な比較に変更：

```go
// Before
if p.Cells[y][x] == 1 {
    u.Set(coord, core.Alive)
}

// After
if p.Cells[y][x] != core.Dead {
    u.Set(coord, p.Cells[y][x])
}
```

### pkg/universe/universe2d.go

レガシー互換性メソッドに非推奨マークを追加：

```go
// GetCells returns the internal cell array (for compatibility with legacy code)
//
// Deprecated: Use Get(coord) with core.CellState instead for type-safe access.
func (u *Universe2D) GetCells() [][]int

// SetCells sets cells from a 2D int array (for compatibility with legacy code)
//
// Deprecated: Use Set(coord, state) with core.CellState instead for type-safe access.
func (u *Universe2D) SetCells(cells [][]int)
```

## 期待効果

### ✅ 型安全性の向上
- マジックナンバー（0, 1）を完全に排除
- コンパイル時の型チェックが有効
- 誤った値の代入を防止

### ✅ 可読性の向上
- `O`（Dead）と`X`（Alive）による視覚的なパターン表現
- パターン構造が一目で理解可能
- コードレビューが容易

### ✅ 拡張性の向上
- 将来的な中間状態（Half-Alive等）の追加が容易
- 型システムによる保護

### ✅ 後方互換性の維持
- 既存のレガシーメソッドは維持
- 非推奨マークで新しいAPIへの移行を促進

## テスト結果

```bash
$ make quality
Formatting code...
go fmt ./...
Running go vet...
go vet ./...
Running tests...
go test -v ./...
...
All quality checks passed!
```

- **全テストパス**: 既存テスト全てが成功 ✅
- **コードフォーマット**: go fmt適用済み ✅
- **静的解析**: go vetクリア ✅

## 関連Issue

Closes #91

## チェックリスト

- [x] 型安全性の向上
- [x] マジックナンバーの排除
- [x] コードの可読性向上
- [x] 後方互換性の維持
- [x] 全テストパス
- [x] go fmt実行済み
- [x] go vet実行済み

🤖 Generated with [Claude Code](https://claude.com/claude-code)